### PR TITLE
OPS-1262: Fixes command line argument parsing

### DIFF
--- a/lib/capistrano/ext/multistage.rb
+++ b/lib/capistrano/ext/multistage.rb
@@ -22,7 +22,7 @@ Capistrano::Configuration.instance.load do
   on :load do
     if stages.include?(ARGV.first)
       # Execute the specified stage so that recipes required in stage can contribute to task list
-      find_and_execute_task(ARGV.first) if ARGV.any?{ |option| option =~ /-T|--tasks|-e|--explain/ }
+      find_and_execute_task(ARGV.first) unless (ARGV & %w(-T --tasks -e --explain)).empty?
     else
       # Execute the default stage so that recipes required in stage can contribute tasks
       find_and_execute_task(default_stage) if exists?(:default_stage)


### PR DESCRIPTION
@primiti 

Can you please review?  The existing regex was matching `-e`'s inside argument strings, preventing us from deploying to the rs-east region.